### PR TITLE
maxlength attribute should be a numerical value

### DIFF
--- a/_docs/custom-attributes.md
+++ b/_docs/custom-attributes.md
@@ -33,7 +33,7 @@ Common attributes `disabled`, `required`, `readonly`, `maxlength` and `pattern` 
     'disabled'  => true,
     'required'  => true,
     'readonly'  => true,
-    'maxlength' => true,
+    'maxlength' => 140,
     'pattern'   => true,
 ),
 
@@ -42,6 +42,6 @@ Common attributes `disabled`, `required`, `readonly`, `maxlength` and `pattern` 
 'disabled'  => true,
 'required'  => true,
 'readonly'  => true,
-'maxlength' => true,
+'maxlength' => 140,
 'pattern'   => true,
 ```


### PR DESCRIPTION
I can think of no reason why the maxlength attribute would be set to 'true' as shown in the documentation. This should only be set to a numerical value, as shown in the minlength example.