### PR TITLE
Attributes accepted - image size

### DIFF
--- a/_docs/fields/image-advanced.md
+++ b/_docs/fields/image-advanced.md
@@ -41,7 +41,7 @@ array(
     // Do not show how many images uploaded/remaining.
     'max_status'       => 'false',
 
-    // Image size that displays in the edit page.
+    // Image size that displays in the edit page. Possible sizes small,medium,large,original
     'image_size'       => 'thumbnail',
 ),
 ```


### PR DESCRIPTION
If no attribute for image_size is provided "thumbnail" is given.

Otherwise classic wp can be used which is: "small, medium, large, original"