### PR TITLE
Removed single quotes from max_status in example

### DIFF
--- a/_docs/fields/file-upload.md
+++ b/_docs/fields/file-upload.md
@@ -45,7 +45,7 @@ array(
     // 'mime_type'        => 'application,audio,video',
 
     // Do not show how many files uploaded/remaining.
-    'max_status'       => 'false',
+    'max_status'       => false,
 ),
 ```
 


### PR DESCRIPTION
wrapping the false value in single quotes results in the value being true.