### PR TITLE
Syntax error

### DIFF
--- a/_docs/fields/image-advanced.md
+++ b/_docs/fields/image-advanced.md
@@ -40,7 +40,7 @@ array(
     'max_file_uploads' => 2,
 
     // Do not show how many images uploaded/remaining.
-    'max_status'       => 'false',
+    'max_status'       => false,
 
     // Image size that displays in the edit page. Possible sizes small,medium,large,original
     'image_size'       => 'thumbnail',


### PR DESCRIPTION
Corrected syntax error in example.

Example had `'false'` instead of `false` sa value for `'max_status'`